### PR TITLE
Fix backend authentication by setting default database credentials. T…

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,7 +1,7 @@
 # MySQL In-Memory Database Configuration for Development
 spring.datasource.url=jdbc:mysql://localhost:3306/tradedevdb?createDatabaseIfNotExist=true
-spring.datasource.username=your_username
-spring.datasource.password=your_password
+spring.datasource.username=root
+spring.datasource.password=password
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # DDL for table creation in MySQL


### PR DESCRIPTION
…he application was failing to start because of placeholder credentials in the development properties file. This change sets a default username and password for the local MySQL database, allowing the application to connect and create the necessary users.